### PR TITLE
Implement overlay for menus instead of blur functionality

### DIFF
--- a/src/components/Global/Menu/Menu.module.scss
+++ b/src/components/Global/Menu/Menu.module.scss
@@ -1,5 +1,21 @@
 @use "@/styles/constants";
 
+.menu-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100lvw;
+    height: 100lvh;
+}
+
+.show {
+    z-index: constants.$overlay-z;
+}
+
+.hide {
+    display: none;
+}
+
 .menu-container {
     --bar-height: 2px;
     --bar-spacing: 4px;
@@ -17,6 +33,7 @@
     --transition-time: 0.2s;
 
     position: relative;
+    z-index: constants.$menu-z;
 
     .menu-button {
         display: flex;

--- a/src/components/Global/Menu/Menu.spec.tsx
+++ b/src/components/Global/Menu/Menu.spec.tsx
@@ -73,4 +73,11 @@ describe("Menu", () => {
         fireEvent.click(screen.getAllByRole("listitem")[0]);
         await waitFor(() => assertMenuClosed());
     });
+
+    it("Closes menu on scroll", async () => {
+        renderMenu();
+        fireEvent.click(button!);
+        fireEvent.scroll(window);
+        await waitFor(() => assertMenuClosed());
+    });
 });

--- a/src/components/Global/Menu/Menu.tsx
+++ b/src/components/Global/Menu/Menu.tsx
@@ -8,7 +8,16 @@ const Menu: React.FC = () => {
     const [open, setOpen] = useState<boolean>(false);
 
     /** Delay between blur and menu close in ms */
-    const DELAY: number = 100;
+    const DELAY: number = 200;
+
+    /**
+     * Gets the correct styling of the menu overlay, based on menu state
+     *
+     * @returns {string} the classes needed to style the menu icon in the correct state
+     */
+    const getOverlayClass = (): string => {
+        return `${styles["menu-overlay"]} ${open ? styles.show : styles.hide}`;
+    };
 
     /**
      * Toggles the state of the menu
@@ -43,65 +52,71 @@ const Menu: React.FC = () => {
     };
 
     return (
-        <div className={styles["menu-container"]} data-testid="menu">
-            <button
-                id="menu-button"
-                className={styles["menu-button"]}
-                onClick={toggleMenu}
-                onBlur={handleClose}
-            >
-                <span className={getBarClass()} />
-                <span className={getBarClass()} />
-                <span className={getBarClass()} />
-            </button>
-            <ul className={getMenuClass()}>
-                <li className={styles["menu-option"]}>
-                    <Link href="/about">
-                        <a className={styles["menu-link"]}>
-                            <div className={styles["menu-icon"]}>
-                                <Image
-                                    src="/assets/icons/about.svg"
-                                    alt="About Me"
-                                    layout="fill"
-                                    objectFit="contain"
-                                />
-                            </div>
-                            About
-                        </a>
-                    </Link>
-                </li>
-                <li className={styles["menu-option"]}>
-                    <Link href="/projects">
-                        <a className={styles["menu-link"]}>
-                            <div className={styles["menu-icon"]}>
-                                <Image
-                                    src="/assets/icons/projects.svg"
-                                    alt="My Projects"
-                                    layout="fill"
-                                    objectFit="contain"
-                                />
-                            </div>
-                            Projects
-                        </a>
-                    </Link>
-                </li>
-                <li className={styles["menu-option"]}>
-                    <Link href="/experience">
-                        <a className={styles["menu-link"]}>
-                            <div className={styles["menu-icon"]}>
-                                <Image
-                                    src="/assets/icons/experience.svg"
-                                    alt="My Experience"
-                                    layout="fill"
-                                    objectFit="contain"
-                                />
-                            </div>
-                            Experience
-                        </a>
-                    </Link>
-                </li>
-            </ul>
-        </div>
+        <>
+            <div
+                className={getOverlayClass()}
+                onClick={() => setOpen(false)}
+                data-testid="menu-overlay"
+            />
+            <div className={styles["menu-container"]} data-testid="menu">
+                <button
+                    id="menu-button"
+                    className={styles["menu-button"]}
+                    onClick={toggleMenu}
+                >
+                    <span className={getBarClass()} data-testid="menu-bar" />
+                    <span className={getBarClass()} />
+                    <span className={getBarClass()} />
+                </button>
+                <ul className={getMenuClass()} onClick={handleClose}>
+                    <li className={styles["menu-option"]}>
+                        <Link href="/about">
+                            <a className={styles["menu-link"]}>
+                                <div className={styles["menu-icon"]}>
+                                    <Image
+                                        src="/assets/icons/about.svg"
+                                        alt="About Me"
+                                        layout="fill"
+                                        objectFit="contain"
+                                    />
+                                </div>
+                                About
+                            </a>
+                        </Link>
+                    </li>
+                    <li className={styles["menu-option"]}>
+                        <Link href="/projects">
+                            <a className={styles["menu-link"]}>
+                                <div className={styles["menu-icon"]}>
+                                    <Image
+                                        src="/assets/icons/projects.svg"
+                                        alt="My Projects"
+                                        layout="fill"
+                                        objectFit="contain"
+                                    />
+                                </div>
+                                Projects
+                            </a>
+                        </Link>
+                    </li>
+                    <li className={styles["menu-option"]}>
+                        <Link href="/experience">
+                            <a className={styles["menu-link"]}>
+                                <div className={styles["menu-icon"]}>
+                                    <Image
+                                        src="/assets/icons/experience.svg"
+                                        alt="My Experience"
+                                        layout="fill"
+                                        objectFit="contain"
+                                    />
+                                </div>
+                                Experience
+                            </a>
+                        </Link>
+                    </li>
+                </ul>
+            </div>
+        </>
     );
 };
 

--- a/src/components/Global/Menu/Menu.tsx
+++ b/src/components/Global/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -20,6 +20,13 @@ const Menu: React.FC = () => {
     };
 
     /**
+     * Closes the menu without any delay
+     */
+    const closeMenu = (): void => {
+        setOpen(false);
+    };
+
+    /**
      * Toggles the state of the menu
      */
     const toggleMenu = (): void => {
@@ -30,7 +37,7 @@ const Menu: React.FC = () => {
      * Closes the menu after some delay to allow for nav
      */
     const handleClose = (): void => {
-        setTimeout(() => setOpen(false), DELAY);
+        setTimeout(closeMenu, DELAY);
     };
 
     /**
@@ -51,11 +58,19 @@ const Menu: React.FC = () => {
         return `${styles.menu} ${open ? styles.open : styles.closed}`;
     };
 
+    useEffect(() => {
+        window.addEventListener("scroll", closeMenu);
+
+        return () => {
+            window.removeEventListener("scroll", closeMenu);
+        };
+    }, []);
+
     return (
         <>
             <div
                 className={getOverlayClass()}
-                onClick={() => setOpen(false)}
+                onClick={closeMenu}
                 data-testid="menu-overlay"
             />
             <div className={styles["menu-container"]} data-testid="menu">

--- a/src/components/Projects/ProjectModal/ProjectModal.module.scss
+++ b/src/components/Projects/ProjectModal/ProjectModal.module.scss
@@ -11,7 +11,7 @@
     top: 0;
     justify-content: center;
     align-items: center;
-    z-index: constants.$modal-z;
+    z-index: constants.$overlay-z;
     animation-duration: var(--animation-time);
     animation-name: fadein;
     background-color: rgba(0, 0, 0, 0.5);

--- a/src/components/Projects/ProjectModal/ProjectModal.spec.tsx
+++ b/src/components/Projects/ProjectModal/ProjectModal.spec.tsx
@@ -8,7 +8,7 @@ import { mockTool1 } from "@/mocks/tools";
 import ProjectModal from "./ProjectModal";
 
 describe("ProjectModal", () => {
-    let overlay: HTMLDivElement | null;
+    let modalOverlay: HTMLDivElement | null;
 
     /**
      * A close handler for testing purposes
@@ -26,18 +26,18 @@ describe("ProjectModal", () => {
                 onClose={mockCloseHandler}
             />,
         );
-        overlay = screen.queryByTestId("overlay");
+        modalOverlay = screen.queryByTestId("modal-overlay");
     };
 
     it("Renders correctly", () => {
         renderProjectModal();
-        expect(overlay).not.toHaveClass("closing");
+        expect(modalOverlay).not.toHaveClass("closing");
         expect(screen.queryByTestId("project-info")).toBeInTheDocument();
     });
 
     it("Calls the close handler when the overlay is clicked", async () => {
         renderProjectModal();
-        fireEvent.click(overlay!);
+        fireEvent.click(modalOverlay!);
         await waitFor(() => expect(mockCloseHandler).toHaveBeenCalled());
     });
 });

--- a/src/components/Projects/ProjectModal/ProjectModal.tsx
+++ b/src/components/Projects/ProjectModal/ProjectModal.tsx
@@ -35,7 +35,7 @@ const ProjectModal: React.FC<ProjectModalProps> = (
             id={MODAL_ID}
             className={styles["project-modal-overlay"]}
             onClick={closeModal}
-            data-testid="overlay"
+            data-testid="modal-overlay"
         >
             <div className={styles["project-modal"]}>
                 <ProjectInfo project={props.project} tools={props.tools} />

--- a/src/components/Projects/ProjectsPage/ProjectsPage.spec.tsx
+++ b/src/components/Projects/ProjectsPage/ProjectsPage.spec.tsx
@@ -20,7 +20,7 @@ describe("ProjectsPage", () => {
      * Checks to see if the component is in a state where no project is set
      */
     const assertProjectUnset = (): void => {
-        expect(screen.queryByTestId("overlay")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("modal-overlay")).not.toBeInTheDocument();
         expect(screen.queryByTestId("project-info")).not.toBeInTheDocument();
         expect(projectDoors[0]).toHaveClass("closed");
         expect(projectDoors[1]).toHaveClass("closed");
@@ -35,7 +35,7 @@ describe("ProjectsPage", () => {
      * @param {string} projectName The name of the project that is being set
      */
     const assertProjectSet = (projectName: string): void => {
-        expect(screen.queryByTestId("overlay")).toBeInTheDocument();
+        expect(screen.queryByTestId("modal-overlay")).toBeInTheDocument();
         expect(screen.queryAllByTestId("project-info").length).toBe(2);
         expect(projectDoors[0]).not.toHaveClass("closed");
         expect(projectDoors[1]).not.toHaveClass("closed");
@@ -86,7 +86,7 @@ describe("ProjectsPage", () => {
         expect(projectButtons[0]).toHaveTextContent(mockProjects[0].name);
         fireEvent.click(projectButtons[0]);
         await waitFor(() => assertProjectSet(mockProjects[0].name));
-        fireEvent.click(screen.getByTestId("overlay"));
+        fireEvent.click(screen.getByTestId("modal-overlay"));
         await waitFor(assertProjectUnset);
     });
 

--- a/src/static/types.ts
+++ b/src/static/types.ts
@@ -3,6 +3,9 @@ import { Project as ProjectModel } from "@prisma/client";
 /** JSX elements rendered conditionally */
 export type ConditionalJSX = JSX.Element | "";
 
+/** HTML element that has been selected by a queryBy... method */
+export type QueriedHTMLElement = HTMLElement | null;
+
 /** Left/right side */
 export type Side = "left" | "right";
 

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -34,4 +34,5 @@ $desktop: 1440px;
 
 // Z-layering
 $navbar-z: 1;
-$modal-z: 99;
+$overlay-z: 99;
+$menu-z: 100;


### PR DESCRIPTION
### To-Do
- [X] Change uses of `overlay` to `modal-overlay` to make testing easier
- [X] Add overlay with click handler to menu instead of using `onBlur`
- [X] Make menu close on scroll
- [X] Fix/add menu tests

### Other Changes
- Introduces a new `QueriedHTMLElement` type for testing

### Issue
Closes #31 