### PR TITLE
Improve timeframes in `ExperiencePage`

### DIFF
--- a/src/components/Experience/ExperienceCard/ExperienceCard.module.scss
+++ b/src/components/Experience/ExperienceCard/ExperienceCard.module.scss
@@ -10,47 +10,63 @@
     --description-spacing: 1rem;
     --header-font-size: 1.5rem;
     --logo-size: 60px;
+    --timeframe-font-size: 1.75rem;
+    --timeframe-letter-spacing: 1px;
+    --timeframe-x-padding: var(--card-padding);
+    --timeframe-y-padding: 0.5rem;
 
     border-radius: var(--card-border-radius);
     background: var(--theme-accent);
-    padding: var(--card-padding);
+    overflow: hidden;
 
-    .card-header {
-        display: flex;
-        align-items: center;
-
-        .card-img {
-            position: relative;
-            margin-right: var(--description-spacing);
-            width: var(--logo-size);
-            height: var(--logo-size);
-        }
-
-        .header-text {
-            .company {
-                font-size: var(--header-font-size);
-                font-family: constants.$header-font;
-                letter-spacing: var(--company-letter-spacing);
-            }
-
-            .title,
-            .timeframe {
-                font-size: var(--body-font-size);
-            }
-        }
+    .timeframe {
+        background-color: var(--theme-hover);
+        padding: var(--timeframe-y-padding) var(--timeframe-x-padding);
+        color: var(--theme-main);
+        font-size: var(--timeframe-font-size);
+        font-family: constants.$header-font;
+        letter-spacing: var(--timeframe-letter-spacing);
     }
 
-    .card-description {
-        margin-top: var(--description-spacing);
-        margin-left: var(--description-offset);
-        list-style-type: circle;
+    .card {
+        padding: var(--card-padding);
 
-        .bullet {
-            margin-bottom: var(--bullet-spacing);
-            font-size: var(--body-font-size);
+        .card-header {
+            display: flex;
+            align-items: center;
 
-            &:last-child {
-                margin-bottom: 0;
+            .card-img {
+                position: relative;
+                margin-right: var(--description-spacing);
+                width: var(--logo-size);
+                height: var(--logo-size);
+            }
+
+            .header-text {
+                .company {
+                    font-size: var(--header-font-size);
+                    font-family: constants.$header-font;
+                    letter-spacing: var(--company-letter-spacing);
+                }
+
+                .title {
+                    font-size: var(--body-font-size);
+                }
+            }
+        }
+
+        .card-description {
+            margin-top: var(--description-spacing);
+            margin-left: var(--description-offset);
+            list-style-type: circle;
+
+            .bullet {
+                margin-bottom: var(--bullet-spacing);
+                font-size: var(--body-font-size);
+
+                &:last-child {
+                    margin-bottom: 0;
+                }
             }
         }
     }
@@ -71,7 +87,11 @@
         --header-font-size: 2rem;
         --logo-size: 80px;
 
-        .card-header > .header-text > .timeframe {
+        .timeframe {
+            display: none;
+        }
+
+        .card > .card-header > .header-text > .timeframe {
             display: none;
         }
     }

--- a/src/components/Experience/ExperienceCard/ExperienceCard.spec.tsx
+++ b/src/components/Experience/ExperienceCard/ExperienceCard.spec.tsx
@@ -7,7 +7,7 @@ import {
     mockEmptyDescriptionExperience,
     mockExperience,
 } from "@/mocks/experiences";
-import { QueriedHTMLElement } from "@/static/types";
+import { QueriedHTMLElement, QueriedHTMLElements } from "@/static/types";
 
 import ExperienceCard, { ExperienceCardProps } from "./ExperienceCard";
 
@@ -33,7 +33,7 @@ describe("ExperienceCard", () => {
      * @param {string[]} description The array of bullet points describing the experience
      */
     const assertDescriptionRenders = (description: string[]): void => {
-        const bullets: HTMLElement[] = screen.queryAllByRole("listitem");
+        const bullets: QueriedHTMLElements = screen.queryAllByRole("listitem");
         expect(experienceDescription).toBeInTheDocument();
         expect(bullets.length).toBe(description.length);
         bullets.forEach((bullet: HTMLElement, idx: number) =>

--- a/src/components/Experience/ExperienceCard/ExperienceCard.spec.tsx
+++ b/src/components/Experience/ExperienceCard/ExperienceCard.spec.tsx
@@ -7,12 +7,13 @@ import {
     mockEmptyDescriptionExperience,
     mockExperience,
 } from "@/mocks/experiences";
+import { QueriedHTMLElement } from "@/static/types";
 
 import ExperienceCard, { ExperienceCardProps } from "./ExperienceCard";
 
 describe("ExperienceCard", () => {
-    let experienceDescription: HTMLUListElement | null;
-    let experienceTimeframe: HTMLParagraphElement | null;
+    let experienceDescription: QueriedHTMLElement;
+    let experienceTimeframe: QueriedHTMLElement;
 
     /**
      * Checks that the basic card components render correctly
@@ -32,10 +33,10 @@ describe("ExperienceCard", () => {
      * @param {string[]} description The array of bullet points describing the experience
      */
     const assertDescriptionRenders = (description: string[]): void => {
-        const bullets: HTMLLIElement[] = screen.queryAllByRole("listitem");
+        const bullets: HTMLElement[] = screen.queryAllByRole("listitem");
         expect(experienceDescription).toBeInTheDocument();
         expect(bullets.length).toBe(description.length);
-        bullets.forEach((bullet: HTMLLIElement, idx: number) =>
+        bullets.forEach((bullet: HTMLElement, idx: number) =>
             expect(bullet).toHaveTextContent(description[idx]),
         );
     };

--- a/src/components/Experience/ExperienceCard/ExperienceCard.tsx
+++ b/src/components/Experience/ExperienceCard/ExperienceCard.tsx
@@ -47,31 +47,30 @@ const ExperienceCard: React.FC<ExperienceCardProps> = (
 
     return (
         <div className={styles["experience-card"]}>
-            <div className={styles["card-header"]}>
-                <div className={styles["card-img"]}>
-                    <Image
-                        src={props.experience.logo}
-                        alt={props.experience.company}
-                        layout="fill"
-                        objectFit="contain"
-                    />
-                </div>
-                <div className={styles["header-text"]}>
-                    <h3 className={styles.company}>
-                        {props.experience.company}
-                    </h3>
-                    <strong className={styles.title}>
-                        {props.experience.title}
-                    </strong>
-                    <p
-                        className={styles.timeframe}
-                        data-testid="card-timeframe"
-                    >
-                        {getTimeframe(props.experience)}
-                    </p>
-                </div>
+            <div className={styles.timeframe} data-testid="card-timeframe">
+                {getTimeframe(props.experience)}
             </div>
-            {getCardDescription()}
+            <div className={styles.card}>
+                <div className={styles["card-header"]}>
+                    <div className={styles["card-img"]}>
+                        <Image
+                            src={props.experience.logo}
+                            alt={props.experience.company}
+                            layout="fill"
+                            objectFit="contain"
+                        />
+                    </div>
+                    <div className={styles["header-text"]}>
+                        <h3 className={styles.company}>
+                            {props.experience.company}
+                        </h3>
+                        <strong className={styles.title}>
+                            {props.experience.title}
+                        </strong>
+                    </div>
+                </div>
+                {getCardDescription()}
+            </div>
         </div>
     );
 };

--- a/src/components/Experience/ExperiencePage/ExperiencePage.module.scss
+++ b/src/components/Experience/ExperiencePage/ExperiencePage.module.scss
@@ -1,7 +1,7 @@
 @use "@/styles/constants";
 
 .experience-page {
-    --experience-spacing: 1rem;
+    --experience-spacing: 2rem;
 
     width: 100%;
 

--- a/src/components/Experience/ExperiencePage/ExperiencePage.module.scss
+++ b/src/components/Experience/ExperiencePage/ExperiencePage.module.scss
@@ -28,7 +28,7 @@
         --page-y-padding: 4rem;
         --timeframe-font-size: 2rem;
         --timeframe-letter-spacing: 1px;
-        --timeframe-x-offset: 80%;
+        --timeframe-x-offset: 100%;
         --timeframe-y-offset: -150%;
         --timeline: var(--timeline-size) solid var(--theme-text);
         --timeline-radius: 40px;

--- a/src/components/Experience/ExperiencePage/ExperiencePage.spec.tsx
+++ b/src/components/Experience/ExperiencePage/ExperiencePage.spec.tsx
@@ -6,23 +6,24 @@ import {
     mockCurrentExperience,
     mockEmptyDescriptionExperience,
 } from "@/mocks/experiences";
+import { QueriedHTMLElement, QueriedHTMLElements } from "@/static/types";
 
 import ExperiencePage, { ExperiencePageProps } from "./ExperiencePage";
 
 describe("ExperiencePage", () => {
-    let experiences: HTMLLIElement[];
-    let timeframes: HTMLParagraphElement[];
-    let endpoint: HTMLDivElement | null;
+    let experiences: QueriedHTMLElements;
+    let timeframes: QueriedHTMLElements;
+    let endpoint: QueriedHTMLElement;
 
     /**
      * Checks that the timeframe is rendered correctly
      *
-     * @param {HTMLParagraphElement} timeframe
+     * @param {HTMLElement} timeframe
      * @param {string} startDate
      * @param {string} endDate
      */
     const assertTimeframeRenders = (
-        timeframe: HTMLParagraphElement,
+        timeframe: HTMLElement,
         startDate: string,
         endDate: string,
     ): void => {
@@ -62,7 +63,7 @@ describe("ExperiencePage", () => {
         });
         expect(experiences.length).toBe(2);
         expect(timeframes.length).toBe(2);
-        timeframes.forEach((timeframe: HTMLParagraphElement) =>
+        timeframes.forEach((timeframe: HTMLElement) =>
             assertTimeframeRenders(
                 timeframe,
                 mockEmptyDescriptionExperience.startDate,

--- a/src/components/Experience/ExperiencePage/ExperiencePage.tsx
+++ b/src/components/Experience/ExperiencePage/ExperiencePage.tsx
@@ -1,3 +1,5 @@
+import { ReactElement } from "react";
+
 import ExperienceCard from "@/components/Experience/ExperienceCard/ExperienceCard";
 import { Experience } from "@/static/types";
 
@@ -11,6 +13,27 @@ export type ExperiencePageProps = {
 const ExperiencePage: React.FC<ExperiencePageProps> = (
     props: ExperiencePageProps,
 ) => {
+    /**
+     * Renders the experience at a given timeline index
+     *
+     * @returns {ReactElement[]} The timeline entries
+     */
+    const renderExperiences = (): ReactElement[] => {
+        return props.experiences.map((experience: Experience, idx: number) => {
+            return (
+                <li className={getExperienceClass(idx)} key={idx}>
+                    <ExperienceCard experience={experience} />
+                    <p
+                        className={styles.timeframe}
+                        data-testid="page-timeframe"
+                    >
+                        {getTimeframe(experience)}
+                    </p>
+                </li>
+            );
+        });
+    };
+
     /**
      * Gets the correct styling of the experience, based on index
      *
@@ -48,19 +71,7 @@ const ExperiencePage: React.FC<ExperiencePageProps> = (
         <div className={styles["experience-page"]}>
             <ul className={styles.timeline}>
                 <div className={styles.arrow} />
-                {props.experiences.map((exp: Experience, idx: number) => {
-                    return (
-                        <li className={getExperienceClass(idx)} key={idx}>
-                            <ExperienceCard experience={exp} />
-                            <p
-                                className={styles.timeframe}
-                                data-testid="page-timeframe"
-                            >
-                                {getTimeframe(exp)}
-                            </p>
-                        </li>
-                    );
-                })}
+                {renderExperiences()}
                 <div className={getEndpointClass()} data-testid="endpoint" />
             </ul>
         </div>

--- a/src/static/types.ts
+++ b/src/static/types.ts
@@ -6,6 +6,9 @@ export type ConditionalJSX = JSX.Element | "";
 /** HTML element that has been selected by a queryBy... method */
 export type QueriedHTMLElement = HTMLElement | null;
 
+/** HTML elements that have been selected by a queryAllBy... method */
+export type QueriedHTMLElements = HTMLElement[];
+
 /** Left/right side */
 export type Side = "left" | "right";
 


### PR DESCRIPTION
### To-Do
- [X] Make timeframes in `ExperienceCard` more visible for mobile displays
- [X] Make timeframes in `ExperiencePage` more centered for desktop displays

### Other Changes
- Backfills `QueriedHTMLElement` in `Experience` unit tests
- Introduces `QueriedHTMLElements` for `queryAllBy...` methods
- Extracts markup from `ExperiencePage` into `renderExperiences` method

Closes #14 