### PR TITLE
Replace specific HTML elements with test types

### DIFF
--- a/src/components/Home/NavCard/NavCard.spec.tsx
+++ b/src/components/Home/NavCard/NavCard.spec.tsx
@@ -2,9 +2,9 @@ import "@testing-library/jest-dom";
 
 import { render, screen } from "@testing-library/react";
 
-import { Side } from "@/static/types";
+import { QueriedHTMLElement, Side } from "@/static/types";
 
-import NavCard, { NavCardProps } from "./NavCard";
+import NavCard from "./NavCard";
 
 describe("NavCard", () => {
     const TEST_TITLE: string = "Test";
@@ -16,7 +16,7 @@ describe("NavCard", () => {
      * @param {Side} side The alignment of the card being tested
      */
     const assertCardRenders = (side: Side): void => {
-        const title: HTMLHeadingElement | null = screen.queryByRole("heading");
+        const title: QueriedHTMLElement = screen.queryByRole("heading");
         expect(title).toHaveTextContent(TEST_TITLE);
         expect(title).toHaveClass(`${side}-title`);
         expect(screen.queryByAltText(TEST_TITLE)).toBeInTheDocument();
@@ -25,26 +25,18 @@ describe("NavCard", () => {
 
     /**
      * Renders the component
-     *
-     * @param {NavCardProps} props Props to pass to the component
      */
-    const renderNavCard = (props: NavCardProps): void => {
-        render(
-            <NavCard
-                title={props.title}
-                path={props.path}
-                align={props.align}
-            />,
-        );
+    const renderNavCard = (align: Side): void => {
+        render(<NavCard title={TEST_TITLE} path={TEST_PATH} align={align} />);
     };
 
     it("Renders correctly when aligned left", () => {
-        renderNavCard({ title: TEST_TITLE, path: TEST_PATH, align: "left" });
+        renderNavCard("left");
         assertCardRenders("left");
     });
 
     it("Renders correctly when aligned right", () => {
-        renderNavCard({ title: TEST_TITLE, path: TEST_PATH, align: "right" });
+        renderNavCard("right");
         assertCardRenders("right");
     });
 });

--- a/src/components/Home/SocialCard/SocialCard.spec.tsx
+++ b/src/components/Home/SocialCard/SocialCard.spec.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 
 import { render, screen } from "@testing-library/react";
 
-import { Social } from "@/static/types";
+import { QueriedHTMLElement, Social } from "@/static/types";
 
 import SocialCard, { SocialCardProps } from "./SocialCard";
 
@@ -18,7 +18,7 @@ describe("SocialCard", () => {
      * @param {Social} social The social media the card represents
      */
     const assertCardRenders = (social: Social): void => {
-        const link: HTMLAnchorElement | null = screen.queryByRole("link");
+        const link: QueriedHTMLElement = screen.queryByRole("link");
         expect(link).toHaveAttribute("href", `https://${social}.com`);
         expect(link).toHaveClass(social);
         expect(screen.queryByAltText(social)).toBeInTheDocument();

--- a/src/components/Projects/ProjectCard/ProjectCard.spec.tsx
+++ b/src/components/Projects/ProjectCard/ProjectCard.spec.tsx
@@ -3,11 +3,12 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import { mockProject } from "@/mocks/projects";
+import { QueriedHTMLElement } from "@/static/types";
 
 import ProjectCard from "./ProjectCard";
 
 describe("ProjectCard", () => {
-    let button: HTMLButtonElement | null;
+    let button: QueriedHTMLElement;
 
     /**
      * A click handler for testing purposes

--- a/src/components/Projects/ProjectDoor/ProjectDoor.spec.tsx
+++ b/src/components/Projects/ProjectDoor/ProjectDoor.spec.tsx
@@ -2,10 +2,12 @@ import "@testing-library/jest-dom";
 
 import { render, screen } from "@testing-library/react";
 
+import { QueriedHTMLElement } from "@/static/types";
+
 import ProjectDoor, { ProjectDoorProps } from "./ProjectDoor";
 
 describe("ProjectDoor", () => {
-    let door: HTMLDivElement | null;
+    let door: QueriedHTMLElement;
 
     /**
      * Checks that the left door is rendered correctly

--- a/src/components/Projects/ProjectInfo/ProjectInfo.spec.tsx
+++ b/src/components/Projects/ProjectInfo/ProjectInfo.spec.tsx
@@ -11,15 +11,16 @@ import {
     mockProject,
 } from "@/mocks/projects";
 import { mockTool1, mockTool2 } from "@/mocks/tools";
+import { QueriedHTMLElement, QueriedHTMLElements } from "@/static/types";
 
 import ProjectInfo, { ProjectInfoProps } from "./ProjectInfo";
 
 describe("ProjectInfo", () => {
-    let images: HTMLImageElement[];
-    let headings: HTMLHeadingElement[];
-    let links: HTMLAnchorElement[];
-    let toolsList: HTMLUListElement | null;
-    let tools: HTMLLIElement[];
+    let images: QueriedHTMLElements;
+    let headings: QueriedHTMLElements;
+    let links: QueriedHTMLElements;
+    let toolsList: QueriedHTMLElement;
+    let tools: QueriedHTMLElements;
 
     /**
      * Checks to see if the tools section is rendered correctly
@@ -34,8 +35,8 @@ describe("ProjectInfo", () => {
      * Checks to see if a GitHub link is rendered correctly
      */
     const assertGitHubLinkRenders = (
-        link: HTMLAnchorElement,
-        image: HTMLImageElement,
+        link: HTMLElement,
+        image: HTMLElement,
         href: string,
     ): void => {
         expect(link).toHaveAttribute("href", href);
@@ -46,8 +47,8 @@ describe("ProjectInfo", () => {
      * Checks to see if a site link is rendered correctly
      */
     const assertSiteLinkRenders = (
-        link: HTMLAnchorElement,
-        image: HTMLImageElement,
+        link: HTMLElement,
+        image: HTMLElement,
         href: string,
     ): void => {
         expect(link).toHaveAttribute("href", href);

--- a/src/components/Projects/ProjectModal/ProjectModal.spec.tsx
+++ b/src/components/Projects/ProjectModal/ProjectModal.spec.tsx
@@ -4,11 +4,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { mockProject } from "@/mocks/projects";
 import { mockTool1 } from "@/mocks/tools";
+import { QueriedHTMLElement } from "@/static/types";
 
 import ProjectModal from "./ProjectModal";
 
 describe("ProjectModal", () => {
-    let modalOverlay: HTMLDivElement | null;
+    let modalOverlay: QueriedHTMLElement;
 
     /**
      * A close handler for testing purposes

--- a/src/components/Projects/ProjectsMenu/ProjectsMenu.spec.tsx
+++ b/src/components/Projects/ProjectsMenu/ProjectsMenu.spec.tsx
@@ -3,13 +3,17 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { mockProjects } from "@/mocks/projects";
-import { Project } from "@/static/types";
+import {
+    Project,
+    QueriedHTMLElement,
+    QueriedHTMLElements,
+} from "@/static/types";
 
 import ProjectsMenu from "./ProjectsMenu";
 
 describe("ProjectsMenu", () => {
-    let menu: HTMLUListElement | null;
-    let buttons: HTMLButtonElement[];
+    let menu: QueriedHTMLElement;
+    let buttons: QueriedHTMLElements;
 
     /**
      * A select handler for testing purposes
@@ -32,7 +36,7 @@ describe("ProjectsMenu", () => {
 
     it("Renders correctly", () => {
         renderProjectsMenu();
-        const cards: HTMLLIElement[] = screen.queryAllByRole("listitem");
+        const cards: QueriedHTMLElements = screen.queryAllByRole("listitem");
         expect(menu).not.toHaveClass("disabled");
         expect(cards.length).toBe(mockProjects.length);
         expect(buttons.length).toBe(mockProjects.length);

--- a/src/components/Projects/ProjectsPage/ProjectsPage.spec.tsx
+++ b/src/components/Projects/ProjectsPage/ProjectsPage.spec.tsx
@@ -4,12 +4,20 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { mockProjects } from "@/mocks/projects";
 import { mockTools } from "@/mocks/tools";
+import { QueriedHTMLElements } from "@/static/types";
 
 import ProjectsPage from "./ProjectsPage";
 
 describe("ProjectsPage", () => {
-    let projectDoors: HTMLDivElement[];
-    let projectButtons: HTMLButtonElement[];
+    const LEFT_DOOR_IDX = 0;
+    const RIGHT_DOOR_IDX = 1;
+    const FIRST_PROJECT_IDX = 0;
+    const SECOND_PROJECT_IDX = 1;
+    const NUM_DOORS = 2;
+    const NUM_INFO_COMPONENTS = 2;
+
+    let projectDoors: QueriedHTMLElements;
+    let projectButtons: QueriedHTMLElements;
 
     /**
      * A mock of Element.scrollTo for testing purposes
@@ -22,8 +30,8 @@ describe("ProjectsPage", () => {
     const assertProjectUnset = (): void => {
         expect(screen.queryByTestId("modal-overlay")).not.toBeInTheDocument();
         expect(screen.queryByTestId("project-info")).not.toBeInTheDocument();
-        expect(projectDoors[0]).toHaveClass("closed");
-        expect(projectDoors[1]).toHaveClass("closed");
+        expect(projectDoors[LEFT_DOOR_IDX]).toHaveClass("closed");
+        expect(projectDoors[RIGHT_DOOR_IDX]).toHaveClass("closed");
         expect(screen.queryByTestId("scroll-container")).toHaveClass(
             "disabled",
         );
@@ -36,14 +44,18 @@ describe("ProjectsPage", () => {
      */
     const assertProjectSet = (projectName: string): void => {
         expect(screen.queryByTestId("modal-overlay")).toBeInTheDocument();
-        expect(screen.queryAllByTestId("project-info").length).toBe(2);
-        expect(projectDoors[0]).not.toHaveClass("closed");
-        expect(projectDoors[1]).not.toHaveClass("closed");
+        expect(screen.queryAllByTestId("project-info").length).toBe(
+            NUM_INFO_COMPONENTS,
+        );
+        expect(projectDoors[LEFT_DOOR_IDX]).not.toHaveClass("closed");
+        expect(projectDoors[RIGHT_DOOR_IDX]).not.toHaveClass("closed");
         expect(mockScrollTo).toHaveBeenCalledWith(0, 0);
         expect(screen.queryByTestId("scroll-container")).not.toHaveClass(
             "disabled",
         );
-        expect(screen.queryAllByAltText(projectName).length).toBe(2);
+        expect(screen.queryAllByAltText(projectName).length).toBe(
+            NUM_INFO_COMPONENTS,
+        );
     };
 
     /**
@@ -58,51 +70,69 @@ describe("ProjectsPage", () => {
 
     it("Renders correctly", () => {
         renderProjectsPage();
-        expect(projectDoors.length).toBe(2);
-        expect(projectDoors[0]).toHaveClass("left");
-        expect(projectDoors[1]).toHaveClass("right");
+        expect(projectDoors.length).toBe(NUM_DOORS);
+        expect(projectDoors[LEFT_DOOR_IDX]).toHaveClass("left");
+        expect(projectDoors[RIGHT_DOOR_IDX]).toHaveClass("right");
         expect(screen.queryByTestId("projects-menu")).toBeInTheDocument();
         assertProjectUnset();
     });
 
     it("Renders components correctly when a project is selected", async () => {
         renderProjectsPage();
-        expect(projectButtons[0]).toHaveTextContent(mockProjects[0].name);
-        fireEvent.click(projectButtons[0]);
-        await waitFor(() => assertProjectSet(mockProjects[0].name));
+        expect(projectButtons[FIRST_PROJECT_IDX]).toHaveTextContent(
+            mockProjects[FIRST_PROJECT_IDX].name,
+        );
+        fireEvent.click(projectButtons[FIRST_PROJECT_IDX]);
+        await waitFor(() =>
+            assertProjectSet(mockProjects[FIRST_PROJECT_IDX].name),
+        );
     });
 
     it("Renders components correctly when a project is unselected from the menu", async () => {
         renderProjectsPage();
-        expect(projectButtons[0]).toHaveTextContent(mockProjects[0].name);
-        fireEvent.click(projectButtons[0]);
-        await waitFor(() => assertProjectSet(mockProjects[0].name));
-        fireEvent.click(projectButtons[0]);
+        expect(projectButtons[FIRST_PROJECT_IDX]).toHaveTextContent(
+            mockProjects[FIRST_PROJECT_IDX].name,
+        );
+        fireEvent.click(projectButtons[FIRST_PROJECT_IDX]);
+        await waitFor(() =>
+            assertProjectSet(mockProjects[FIRST_PROJECT_IDX].name),
+        );
+        fireEvent.click(projectButtons[FIRST_PROJECT_IDX]);
         await waitFor(assertProjectUnset);
     });
 
     it("Renders components correctly when a project is unselected from the modal", async () => {
         renderProjectsPage();
-        expect(projectButtons[0]).toHaveTextContent(mockProjects[0].name);
-        fireEvent.click(projectButtons[0]);
-        await waitFor(() => assertProjectSet(mockProjects[0].name));
+        expect(projectButtons[FIRST_PROJECT_IDX]).toHaveTextContent(
+            mockProjects[FIRST_PROJECT_IDX].name,
+        );
+        fireEvent.click(projectButtons[FIRST_PROJECT_IDX]);
+        await waitFor(() =>
+            assertProjectSet(mockProjects[FIRST_PROJECT_IDX].name),
+        );
         fireEvent.click(screen.getByTestId("modal-overlay"));
         await waitFor(assertProjectUnset);
     });
 
     it("Renders components correctly when a different project is selected", async () => {
         renderProjectsPage();
-        expect(projectButtons[0]).toHaveTextContent(mockProjects[0].name);
-        fireEvent.click(projectButtons[0]);
-        await waitFor(() => assertProjectSet(mockProjects[0].name));
-        fireEvent.click(projectButtons[1]);
+        expect(projectButtons[FIRST_PROJECT_IDX]).toHaveTextContent(
+            mockProjects[FIRST_PROJECT_IDX].name,
+        );
+        fireEvent.click(projectButtons[FIRST_PROJECT_IDX]);
+        await waitFor(() =>
+            assertProjectSet(mockProjects[FIRST_PROJECT_IDX].name),
+        );
+        fireEvent.click(projectButtons[SECOND_PROJECT_IDX]);
         await waitFor(() => {
-            expect(projectDoors[0]).toHaveClass("closed");
-            expect(projectDoors[1]).toHaveClass("closed");
+            expect(projectDoors[LEFT_DOOR_IDX]).toHaveClass("closed");
+            expect(projectDoors[RIGHT_DOOR_IDX]).toHaveClass("closed");
             expect(screen.queryByTestId("scroll-container")).toHaveClass(
                 "disabled",
             );
         });
-        await waitFor(() => assertProjectSet(mockProjects[1].name));
+        await waitFor(() =>
+            assertProjectSet(mockProjects[SECOND_PROJECT_IDX].name),
+        );
     });
 });

--- a/src/components/Projects/ToolTag/ToolTag.spec.tsx
+++ b/src/components/Projects/ToolTag/ToolTag.spec.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
 import { mockTool1 } from "@/mocks/tools";
+import { QueriedHTMLElement } from "@/static/types";
 
 import ToolTag, { ToolTagProps } from "./ToolTag";
 
@@ -18,7 +19,7 @@ describe("ToolTag", () => {
 
     it("Renders correctly", () => {
         renderToolTag({ tool: mockTool1 });
-        const tag: HTMLLIElement | null = screen.queryByRole("listitem");
+        const tag: QueriedHTMLElement = screen.queryByRole("listitem");
         expect(tag).toHaveStyle({ backgroundColor: mockTool1.color });
         expect(tag).toHaveTextContent(mockTool1.name);
     });


### PR DESCRIPTION
### To-Do
- [X] Replace any instances of `HTML...Element | null` and `HTML...Element[]` with `QueriedHTMLElement` and `QueriedHTMLElements`, respectively

Closes #35  